### PR TITLE
install default-jdk additionally to work around the circular dependen…

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -65,8 +65,9 @@ RUN \
     chown gotenberg: /home/gotenberg &&\
     # Install dependencies required for the next instructions or debugging.
     # Note: tini is a helper for reaping zombie processes.
+    # Note: ca-certificates-java, default-jdk, openjdk-17-jre-headless installed in this order to avoid https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1030129
     apt-get update -qq &&\
-    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends curl gnupg htop tini python3 openjdk-17-jre-headless &&\
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends curl gnupg htop tini python3 ca-certificates-java default-jdk openjdk-17-jre-headless &&\
     ln -s /usr/bin/htop /usr/bin/top &&\
     # Install fonts.
     # Credits:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -22,13 +22,13 @@ COPY cmd ./cmd
 COPY pkg ./pkg
 
 # Build the binary.
-ARG GOTENBERG_VERSION=7.7.5
+ARG GOTENBERG_VERSION=7.7.6
 
 RUN go build -o gotenberg -ldflags "-X 'github.com/gotenberg/gotenberg/v7/cmd.Version=$GOTENBERG_VERSION'" cmd/gotenberg/main.go
 
 FROM debian:11-slim
 
-ARG GOTENBERG_VERSION=7.7.5
+ARG GOTENBERG_VERSION=7.7.6
 
 LABEL author="Julien Neuhart" \
       description="A Docker-powered stateless API for PDF files." \


### PR DESCRIPTION
install default-jdk additionally to work around the circular dependency in ca-certificates-java package